### PR TITLE
Security, prevent XSS by enabling safe mode

### DIFF
--- a/wizMarkdown/src/wizMarkdown.svc.js
+++ b/wizMarkdown/src/wizMarkdown.svc.js
@@ -3,7 +3,7 @@
 .factory('wizMarkdownSvc', [function () {
 	var markdownSvc = new MarkdownDeep.Markdown();
 	markdownSvc.ExtraMode = true;
-	markdownSvc.SafeMode = false;
+	markdownSvc.SafeMode = true;
 	markdownSvc.NewWindowForExternalLinks = true;
 	markdownSvc.AutoHeadingIDs = true;
     markdownSvc.MarkdownDeepEditor = MarkdownDeepEditor;


### PR DESCRIPTION
Safe mode sanitizes output to prevent XSS
It should be enabled by default to prevent XSS. The user can disable but he'll know it's unsafe !
See "Safe Mode" http://www.toptensoftware.com/markdowndeep/features